### PR TITLE
feat: #20 Database updates for households

### DIFF
--- a/cmd/web/templates/profile_form.html
+++ b/cmd/web/templates/profile_form.html
@@ -38,6 +38,15 @@
                     }}hidden{{end}}>{{.Errors.Email}}</small>
             </div>
         </div>
+        <div class="form-input-group">
+            <label for="household-name">Household name</label>
+            <div class="flex-column">
+                <input type="text" id="household-name" name="householdName" value="{{.HouseholdName}}" />
+                <small>This is what shows up when you claim a gift request</small>
+                <small id="household-error" class="danger" {{if eq .Errors.Household ""
+                    }}hidden{{end}}>{{.Errors.Household}}</small>
+            </div>
+        </div>
         <div class="w-100">
             <button id="profile-submit" class="btn btn-contained primary w-100" type="submit">Update</button>
         </div>

--- a/internal/database/migrations/20250401_000000_create_person_table.sql
+++ b/internal/database/migrations/20250401_000000_create_person_table.sql
@@ -1,9 +1,12 @@
 CREATE TABLE IF NOT EXISTS person (
     person_id SERIAL PRIMARY KEY, 
     email VARCHAR(255) NOT NULL UNIQUE,
-    external_id CHAR(40) UNIQUE NOT NULL 
-        CONSTRAINT ext_id_not_empty CHECK (TRIM(BOTH FROM external_id) <> ''),
+       CONSTRAINT email_not_empty CHECK (TRIM(BOTH FROM email) <> ''),
+    external_id CHAR(40) UNIQUE NOT NULL,
+      CONSTRAINT ext_id_not_empty CHECK (TRIM(BOTH FROM external_id) <> ''),
     first_name VARCHAR(255) NOT NULL,
+       CONSTRAINT first_name_not_empty CHECK (TRIM(BOTH FROM first_name) <> ''),
     last_name VARCHAR(255) NOT NULL,
+       CONSTRAINT last_name_not_empty CHECK (TRIM(BOTH FROM last_name) <> ''),
     display_name VARCHAR(255) NOT NULL
 );

--- a/internal/database/migrations/20250401_000100_create_session_table.sql
+++ b/internal/database/migrations/20250401_000100_create_session_table.sql
@@ -1,1 +1,6 @@
-CREATE TABLE IF NOT EXISTS session (session_id VARCHAR(255) PRIMARY KEY NOT NULL, person_id INTEGER REFERENCES person (person_id), expiration TIMESTAMP NOT NULL, user_agent BPCHAR);
+CREATE TABLE IF NOT EXISTS session (
+    session_id VARCHAR(255) PRIMARY KEY NOT NULL, 
+    person_id INTEGER REFERENCES person (person_id), 
+    expiration TIMESTAMP NOT NULL, 
+    user_agent BPCHAR
+);

--- a/internal/database/migrations/20250803_155000_create_verification_table.sql
+++ b/internal/database/migrations/20250803_155000_create_verification_table.sql
@@ -1,1 +1,6 @@
-CREATE TABLE IF NOT EXISTS verification (person_id INTEGER PRIMARY KEY REFERENCES person (person_id), token VARCHAR(255) NOT NULL, token_expiration TIMESTAMP WITH TIME ZONE, attempts SMALLINT DEFAULT 0);
+CREATE TABLE IF NOT EXISTS verification (
+    person_id INTEGER PRIMARY KEY REFERENCES person (person_id), 
+    token VARCHAR(255) NOT NULL, 
+    token_expiration TIMESTAMP WITH TIME ZONE, 
+    attempts SMALLINT DEFAULT 0
+);

--- a/internal/database/migrations/20251111_070000_create_household_table.sql
+++ b/internal/database/migrations/20251111_070000_create_household_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS household (
+    household_id SERIAL PRIMARY KEY,
+    external_id CHAR(40) UNIQUE NOT NULL 
+        CONSTRAINT ext_id_not_empty CHECK (TRIM(BOTH FROM external_id) <> ''),
+    name VARCHAR(255) UNIQUE NOT NULL
+        CONSTRAINT name_not_empty CHECK (TRIM(BOTH FROM name) <> '')
+);

--- a/internal/database/migrations/20251111_070500_create_household_person_table.sql
+++ b/internal/database/migrations/20251111_070500_create_household_person_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS household_person (
+    household_id INTEGER REFERENCES household (household_id),
+    person_id INTEGER PRIMARY KEY REFERENCES person (person_id),
+    CONSTRAINT one_household_per_person UNIQUE(household_id, person_id)
+);

--- a/internal/database/migrations/20251111_071000_create_household_person_indexing.sql
+++ b/internal/database/migrations/20251111_071000_create_household_person_indexing.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS household_id on household_person (household_id);

--- a/internal/database/migrations_test/success/20250401_000100_insert_test_person.sql
+++ b/internal/database/migrations_test/success/20250401_000100_insert_test_person.sql
@@ -1,4 +1,1 @@
-BEGIN TRANSACTION;
 INSERT INTO person (email, first_name, last_name) VALUES ('test.user@yopmail.com', 'Test', 'User');
-COMMIT TRANSACTION;
-

--- a/internal/health/health_check_handlers_test.go
+++ b/internal/health/health_check_handlers_test.go
@@ -360,6 +360,12 @@ func (db testDB) Execute(ctx context.Context, statement string, params ...any) (
 
 }
 
+func (db testDB) ExecuteBatch(ctx context.Context, statement []string, params [][]any) ([]sql.Result, []error) {
+
+	return []sql.Result{}, []error{sql.ErrNoRows}
+
+}
+
 func (db testDB) Ping(ctx context.Context) error {
 
 	return db.db.Ping()

--- a/internal/middleware/telemetry.go
+++ b/internal/middleware/telemetry.go
@@ -82,7 +82,7 @@ func Telemetry(svr *util.ServerUtils, next http.Handler) http.Handler {
 		}
 
 		svr.Logger.InfoContext(ctx,
-			fmt.Sprintf("Finished the operation %s", req.URL.Path),
+			fmt.Sprintf("Finished the %s operation %s", req.Method, req.URL.Path),
 			logAttrs...,
 		)
 

--- a/internal/profile/profile_handlers.go
+++ b/internal/profile/profile_handlers.go
@@ -15,23 +15,49 @@ type profileErrors struct {
 	Email        string
 	ErrorMessage string
 	FirstName    string
+	Household    string
 	LastName     string
 }
 
 type userData struct {
-	DisplayName string
-	Errors      profileErrors
-	Email       string
-	FirstName   string
-	LastName    string
-	personID    int64
-	valid       bool
+	DisplayName   string
+	Errors        profileErrors
+	Email         string
+	FirstName     string
+	HouseholdName string
+	LastName      string
+	householdID   int64
+	personID      int64
+	valid         bool
 }
 
 const (
-	lookupPersonQuery = "SELECT person_id, email, first_name, last_name, display_name FROM person WHERE person_id = $1"
-	updatePersonQuery = "UPDATE person SET email = $1, first_name = $2, last_name = $3, display_name = $4 WHERE person_id = $5"
-	varcharMaxLength  = 255
+	lookupPersonQuery = `
+		SELECT p.person_id, 
+			h.household_id,
+			p.email, 
+			p.first_name, 
+			p.last_name, 
+			p.display_name, 
+			h.name
+		FROM person p
+			INNER JOIN household_person hp ON p.person_id = hp.person_id
+			INNER JOIN household h ON hp.household_id = h.household_id
+		WHERE p.person_id = $1
+	`
+	updatePersonQuery = `
+		UPDATE person SET email = $1, first_name = $2, last_name = $3, display_name = $4 
+		WHERE person_id = $5
+	`
+	updateHouseholdQuery = `
+		UPDATE household AS h  
+		SET name = $1	
+		FROM household_person AS hp
+			JOIN person AS p ON hp.person_id = p.person_id
+		WHERE hp.household_id = h.household_id
+			AND p.person_id = $2
+	`
+	varcharMaxLength = 255
 )
 
 // Looks up the person information and returns it.
@@ -43,7 +69,16 @@ func ProfileHandler(svr *util.ServerUtils) http.HandlerFunc {
 
 		var user userData
 		personID := middleware.PersonID(res, req)
-		svr.DB.QueryRow(ctx, lookupPersonQuery, personID).Scan(&user.personID, &user.Email, &user.FirstName, &user.LastName, &user.DisplayName)
+		svr.DB.QueryRow(ctx, lookupPersonQuery, personID).
+			Scan(
+				&user.personID,
+				&user.householdID,
+				&user.Email,
+				&user.FirstName,
+				&user.LastName,
+				&user.DisplayName,
+				&user.HouseholdName,
+			)
 
 		/*
 			By default we display people by first name, but that can be overridden in
@@ -55,9 +90,11 @@ func ProfileHandler(svr *util.ServerUtils) http.HandlerFunc {
 
 		attributes := middleware.TelemetryAttributes(ctx)
 		attributes = append(attributes, attribute.Int64("personID", user.personID))
+		attributes = append(attributes, attribute.Int64("householdID", user.householdID))
 		attributes = append(attributes, attribute.String("firstName", user.FirstName))
 		attributes = append(attributes, attribute.String("lastName", user.LastName))
 		attributes = append(attributes, attribute.String("displayName", user.DisplayName))
+		attributes = append(attributes, attribute.String("householdName", user.HouseholdName))
 		ctx = middleware.WriteTelemetry(ctx, attributes)
 		_ = req.WithContext(ctx)
 
@@ -99,6 +136,11 @@ func ProfileUpdateHandler(svr *util.ServerUtils) http.Handler {
 		ctx := req.Context()
 		attributes := middleware.TelemetryAttributes(ctx)
 		personID := middleware.PersonID(res, req)
+		svr.Logger.DebugContext(
+			ctx,
+			"Found the person ID from the session",
+			slog.Int64("personID", personID),
+		)
 
 		err := req.ParseForm()
 		if err != nil {
@@ -113,16 +155,23 @@ func ProfileUpdateHandler(svr *util.ServerUtils) http.Handler {
 		}
 
 		user := userData{
-			DisplayName: req.FormValue("displayName"),
-			Email:       req.FormValue("email"),
-			FirstName:   req.FormValue("firstName"),
-			LastName:    req.FormValue("lastName"),
+			DisplayName:   req.FormValue("displayName"),
+			Email:         req.FormValue("email"),
+			FirstName:     req.FormValue("firstName"),
+			HouseholdName: req.FormValue("householdName"),
+			LastName:      req.FormValue("lastName"),
 		}
+		svr.Logger.DebugContext(
+			ctx,
+			"Received a profile update request",
+			slog.Any("submittedData", user),
+		)
 
 		attributes = append(attributes, attribute.Int64("personID", personID))
 		attributes = append(attributes, attribute.String("updatedDisplayName", user.DisplayName))
 		attributes = append(attributes, attribute.String("updatedEmail", user.Email))
 		attributes = append(attributes, attribute.String("updatedFirstName", user.FirstName))
+		attributes = append(attributes, attribute.String("updatedHouseholdName", user.HouseholdName))
 		attributes = append(attributes, attribute.String("updatedLastName", user.LastName))
 
 		tmpl, err := template.ParseFiles(svr.Getenv("TEMPLATES_DIR") + "/profile_form.html")
@@ -147,6 +196,11 @@ func ProfileUpdateHandler(svr *util.ServerUtils) http.Handler {
 		}
 
 		user.validate()
+		svr.Logger.DebugContext(
+			ctx,
+			"Validated submitted user data",
+			slog.Any("userData", user),
+		)
 		attributes = append(attributes, attribute.Bool("dataValid", user.valid))
 		ctx = middleware.WriteTelemetry(ctx, attributes)
 		_ = req.WithContext(ctx)
@@ -170,34 +224,42 @@ func ProfileUpdateHandler(svr *util.ServerUtils) http.Handler {
 			return
 		}
 
-		_, err = svr.DB.Execute(ctx, updatePersonQuery, user.Email, user.FirstName, user.LastName, user.DisplayName, personID)
-		if err != nil {
-			svr.Logger.ErrorContext(
-				ctx,
-				"Error updating the profile information",
-				slog.String("errorMessage", err.Error()),
-			)
-
-			user.Errors.ErrorMessage = "Could not save the profile update"
-			err = tmpl.ExecuteTemplate(res, "profile-page", user)
+		sqlStatements := []string{updatePersonQuery, updateHouseholdQuery}
+		sqlParams := [][]any{{user.Email, user.FirstName, user.LastName, user.DisplayName, personID}, {user.HouseholdName, personID}}
+		_, errs := svr.DB.ExecuteBatch(ctx, sqlStatements, sqlParams)
+		for _, err := range errs {
 			if err != nil {
 				svr.Logger.ErrorContext(
 					ctx,
-					"Error writing the profile page error messages",
+					"Error updating the profile information",
 					slog.String("errorMessage", err.Error()),
 				)
-				/*
-					We're returning early error or no, so don't need a return statement here
-				*/
 
+				user.Errors.ErrorMessage = "Could not save the profile update"
+				err = tmpl.ExecuteTemplate(res, "profile-page", user)
+				if err != nil {
+					svr.Logger.ErrorContext(
+						ctx,
+						"Error writing the profile page error messages",
+						slog.String("errorMessage", err.Error()),
+					)
+					/*
+						We're returning early error or no, so don't need a return statement here
+					*/
+				}
+				return
 			}
-
-			return
-
 		}
 
 		/* On save, return the form with the updated database values */
-		svr.DB.QueryRow(ctx, lookupPersonQuery, personID).Scan(&user.personID, &user.Email, &user.FirstName, &user.LastName, &user.DisplayName)
+		var otherUser userData
+		svr.DB.QueryRow(ctx, lookupPersonQuery, personID).Scan(&otherUser.personID, &otherUser.householdID, &otherUser.Email, &otherUser.FirstName, &otherUser.LastName, &otherUser.DisplayName, &otherUser.HouseholdName)
+		svr.Logger.DebugContext(
+			ctx,
+			"Looked up the user profile data from the database",
+			slog.Any("user", user),
+			slog.Any("otherUser", otherUser),
+		)
 		err = tmpl.ExecuteTemplate(res, "profile-form", user)
 		if err != nil {
 			svr.Logger.ErrorContext(
@@ -218,23 +280,38 @@ func (user *userData) validate() {
 
 	user.valid = true
 
-	if user.Email == "" || len(user.Email) > varcharMaxLength {
+	if user.Email == "" {
 
-		user.Errors.Email = fmt.Sprintf("Email address must be between 1 and %d characters", varcharMaxLength)
+		user.Errors.Email = "Email address is required"
+		user.valid = false
+
+	} else if len(user.Email) > varcharMaxLength {
+
+		user.Errors.Email = fmt.Sprintf("Email address can't be more than %d characters", varcharMaxLength)
 		user.valid = false
 
 	}
 
-	if user.FirstName == "" || len(user.FirstName) > varcharMaxLength {
+	if user.FirstName == "" {
 
-		user.Errors.FirstName = fmt.Sprintf("First name must be between 1 and %d characters", varcharMaxLength)
+		user.Errors.FirstName = "First name is required"
+		user.valid = false
+
+	} else if len(user.FirstName) > varcharMaxLength {
+
+		user.Errors.FirstName = fmt.Sprintf("First name can't be more than %d characters", varcharMaxLength)
 		user.valid = false
 
 	}
 
-	if user.LastName == "" || len(user.LastName) > varcharMaxLength {
+	if user.LastName == "" {
 
-		user.Errors.LastName = fmt.Sprintf("Last name must be between 1 and %d characters", varcharMaxLength)
+		user.Errors.LastName = "Last name is required"
+		user.valid = false
+
+	} else if len(user.LastName) > varcharMaxLength {
+
+		user.Errors.LastName = fmt.Sprintf("Last name can't be more than %d characters", varcharMaxLength)
 		user.valid = false
 
 	}
@@ -242,6 +319,18 @@ func (user *userData) validate() {
 	if user.DisplayName != "" && len(user.DisplayName) > varcharMaxLength {
 
 		user.Errors.LastName = fmt.Sprintf("Display name must no more than %d characters", varcharMaxLength)
+		user.valid = false
+
+	}
+
+	if user.HouseholdName == "" {
+
+		user.Errors.Household = "Household name is required"
+		user.valid = false
+
+	} else if len(user.HouseholdName) > varcharMaxLength {
+
+		user.Errors.Household = fmt.Sprintf("Household name cannot be more than %d characters", varcharMaxLength)
 		user.valid = false
 
 	}


### PR DESCRIPTION
Added a household and household_person table for holding the household name and managing a many-to-one relationship between households and the people in them. Updated the profile page to include the household name (members of the household can change the name). Also added the ability to update the household from the profile edit form.