### PR TITLE
fix: Fixed span attributes on traces

### DIFF
--- a/internal/server/application_handlers.go
+++ b/internal/server/application_handlers.go
@@ -5,6 +5,8 @@ import (
 	"html/template"
 	"log/slog"
 	"net/http"
+
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Returns the landing page for the application
@@ -13,6 +15,8 @@ func IndexHandler(svr *util.ServerUtils) http.Handler {
 	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 
 		ctx := req.Context()
+		span := trace.SpanFromContext(ctx)
+		span.SetName("index_handler")
 
 		dir := svr.Getenv("TEMPLATES_DIR")
 		tmpl, tmplErr := template.ParseFiles(dir + "/index.html")

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -46,8 +46,8 @@ func registerRoutes() (http.Handler, error) {
 	handler := otelhttp.NewHandler(
 		middleware.Cors(
 			appSrv,
-			middleware.Auth(appSrv,
-				middleware.Telemetry(appSrv, mux),
+			middleware.Telemetry(appSrv,
+				middleware.Auth(appSrv, mux),
 			),
 		),
 		"/",


### PR DESCRIPTION
login_handlers the canonical reference, although most of the work is done on the others. Just need to go through and make sure the spans are set up exactly right to name and pull from context without an End() call to make sure the middleware and handler calls are all 1 span.

Also still need to get the attributes into the canonical log line, but the link to the trace ID should be good enough for an initial release.

fix: Updated span attributes

Want to get these attributes into the canonical log lines, as well as eliminate most of the non-canonical lines, but at least the traces look better. Some minor cleanup on some data (paths get repeated twice), but good enough for an "in-progress" release.